### PR TITLE
mesa: lib32 - Properly check for Vulkan directory, then copy it

### DIFF
--- a/mesa
+++ b/mesa
@@ -43,8 +43,8 @@ ninja
 
 DESTDIR=$PWD/DESTDIR ninja install
 cp -vr DESTDIR/$XORG_PREFIX/lib32/* $XORG_PREFIX/lib32
-if [ -f DESTDIR/$XORG_PREFIX/share/vulkan ]; then
-     cp -vr DESTDIR/$XORG_PREFIX/share/vulkan/* $XORG_PREFIX/share/vulkan
+if [ -d DESTDIR/$XORG_PREFIX/share/vulkan ]; then
+     cp -vr DESTDIR/$XORG_PREFIX/share/vulkan $XORG_PREFIX/share
 fi
 rm -rf DESTDIR
 ldconfig


### PR DESCRIPTION
`-f` is for files when using **[**, while `-d` is for directories. I made this mistake earlier in GLFS and have changed it a couple days ago.

Also, I made it so the Vulkan directory, if it exists in the lib32 `DESTDIR` directory, should be directory copied to `/usr/share` instead of the contents `vulkan/` to `/usr/share/vulkan`. `/usr/share/vulkan` may not exist by this point so this change will create and populate it.